### PR TITLE
Handle malformed payloads gracefully in SQS Inbounds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.synapse.inbound.amazonsqs</groupId>
     <artifactId>org.apache.synapse.amazonsqs.poll.class</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.2</version>
     <name>AmazonSQS Polling Consumer</name>
     <url>http://wso2.org</url>
     <packaging>bundle</packaging>

--- a/src/main/java/org/wso2/carbon/inbound/amazonsqs/AmazonSQSConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/amazonsqs/AmazonSQSConstants.java
@@ -25,6 +25,8 @@ package org.wso2.carbon.inbound.amazonsqs;
  */
 public class AmazonSQSConstants {
     public static final String AMAZONSQS_SQS_WAIT_TIME = "wait_time";
+    public static final String MALFORMED_PAYLOAD = "MALFORMED_PAYLOAD";
+    public static final String MESSAGE_BUILD_FAILURE = "700803";
     public static final String AMAZONSQS_SQS_MAX_NO_OF_MESSAGE = "maxNoOfMessage";
     public static final String DESTINATION = "destination";
     public static final String AMAZONSQS_ACCESSKEY = "accessKey";


### PR DESCRIPTION


## Purpose
Give the capability to remove the malformed payload from the queue and process it through the onError sequence.

Fixes: https://github.com/wso2/micro-integrator/issues/3399